### PR TITLE
feat: add user confirmation before executing hooks

### DIFF
--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -15,7 +15,7 @@ pub mod hooks;
 pub use file_copy::copy_configured_files;
 pub use filesystem::{FileSystem, RealFileSystem};
 pub use git::{GitWorktreeManager, WorktreeInfo};
-pub use hooks::{execute_hooks, HookContext};
+pub use hooks::{execute_hooks, execute_hooks_with_ui, HookContext};
 
 // Re-export FilesConfig from config module
 pub use super::config::FilesConfig;


### PR DESCRIPTION
## Description

This PR adds user confirmation prompts before executing lifecycle hooks (post-create, pre-remove, post-switch). Users are now shown the list of hooks that will be executed and can choose to proceed or skip execution.

### Main changes:
- Added `execute_hooks_with_ui()` function that accepts a `UserInterface` parameter
- Shows expanded hook commands before execution
- Prompts user with "Execute {hook_type} hooks?" (default: yes)
- Maintains backward compatibility with legacy `execute_hooks()` wrapper
- Added comprehensive tests for the confirmation functionality

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tests pass locally with `cargo test`
- [x] Added new tests for new functionality
- [x] Manual testing completed

## Checklist

- [x] My code follows the style guidelines (`cargo fmt`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`cargo clippy`)
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Example of hook confirmation prompt:
```
Running post-create hooks found:
  • echo '🤖 Created worktree: feature-xyz'
  • echo '🤖 Path: /workspace/feature-xyz'

Execute post-create hooks? (Y/n)
```
